### PR TITLE
Replace ITileEntityProvider with hasTileEntity and createTileEntity and fix Accessors ghosting block placements

### DIFF
--- a/src/main/java/com/aranaira/arcanearchives/blocks/AccessorBlock.java
+++ b/src/main/java/com/aranaira/arcanearchives/blocks/AccessorBlock.java
@@ -152,6 +152,7 @@ public class AccessorBlock extends BlockTemplate
 	@Override
 	public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ)
 	{
+		if (world.isRemote) return true;
 		TileEntity te = world.getTileEntity(pos);
 
 		if(te instanceof AccessorTileEntity)

--- a/src/main/java/com/aranaira/arcanearchives/blocks/AccessorBlock.java
+++ b/src/main/java/com/aranaira/arcanearchives/blocks/AccessorBlock.java
@@ -5,7 +5,6 @@ import com.aranaira.arcanearchives.init.BlockLibrary;
 import com.aranaira.arcanearchives.tileentities.AATileEntity;
 import com.aranaira.arcanearchives.tileentities.AccessorTileEntity;
 import mcp.MethodsReturnNonnullByDefault;
-import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.EnumPushReaction;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
@@ -49,7 +48,7 @@ import java.util.Random;
 @SuppressWarnings("deprecation")
 // TODO: Break textures
 // TODO: WAILA, TUMAT, TOP, etc support
-public class AccessorBlock extends BlockTemplate implements ITileEntityProvider
+public class AccessorBlock extends BlockTemplate
 {
 	public static final PropertyInteger TYPE = PropertyInteger.create("type", 0, 15);
 
@@ -329,11 +328,10 @@ public class AccessorBlock extends BlockTemplate implements ITileEntityProvider
 		return getBlock(blockState).getComparatorInputOverride(blockState, worldIn, pos);
 	}
 
-	@Nullable
 	@Override
-	public TileEntity createNewTileEntity(World worldIn, int meta)
-	{
-		return new AccessorTileEntity();
-	}
+	public boolean hasTileEntity(IBlockState state) { return true; }
+
+	@Override
+	public TileEntity createTileEntity(World world, IBlockState state) { return new AccessorTileEntity(); }
 }
 

--- a/src/main/java/com/aranaira/arcanearchives/blocks/GemCuttersTable.java
+++ b/src/main/java/com/aranaira/arcanearchives/blocks/GemCuttersTable.java
@@ -5,7 +5,6 @@ import com.aranaira.arcanearchives.common.AAGuiHandler;
 import com.aranaira.arcanearchives.tileentities.GemCuttersTableTileEntity;
 import com.aranaira.arcanearchives.util.DropHelper;
 import mcp.MethodsReturnNonnullByDefault;
-import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.util.ITooltipFlag;
@@ -27,7 +26,7 @@ import java.util.List;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class GemCuttersTable extends BlockDirectionalTemplate implements ITileEntityProvider
+public class GemCuttersTable extends BlockDirectionalTemplate
 {
 	public static final String name = "gemcutters_table";
 
@@ -45,12 +44,6 @@ public class GemCuttersTable extends BlockDirectionalTemplate implements ITileEn
 
 	@Override
 	public boolean hasOBJModel()
-	{
-		return true;
-	}
-
-	@Override
-	public boolean hasTileEntity(IBlockState state)
 	{
 		return true;
 	}
@@ -110,8 +103,11 @@ public class GemCuttersTable extends BlockDirectionalTemplate implements ITileEn
 	}
 
 	@Override
-	public TileEntity createNewTileEntity(World worldIn, int meta)
+	public boolean hasTileEntity(IBlockState state)
 	{
-		return new GemCuttersTableTileEntity();
+		return true;
 	}
+
+	@Override
+	public TileEntity createTileEntity(World world, IBlockState state) { return new GemCuttersTableTileEntity(); }
 }

--- a/src/main/java/com/aranaira/arcanearchives/blocks/MatrixCrystalCore.java
+++ b/src/main/java/com/aranaira/arcanearchives/blocks/MatrixCrystalCore.java
@@ -5,7 +5,6 @@ import com.aranaira.arcanearchives.common.AAGuiHandler;
 import com.aranaira.arcanearchives.tileentities.ImmanenceTileEntity;
 import com.aranaira.arcanearchives.tileentities.MatrixCoreTileEntity;
 import mcp.MethodsReturnNonnullByDefault;
-import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyDirection;
 import net.minecraft.block.state.IBlockState;
@@ -20,14 +19,13 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 import java.util.Random;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class MatrixCrystalCore extends BlockDirectionalTemplate implements ITileEntityProvider
+public class MatrixCrystalCore extends BlockDirectionalTemplate
 {
 	public static final PropertyDirection FACING = PropertyDirection.create("facing");
 
@@ -99,10 +97,10 @@ public class MatrixCrystalCore extends BlockDirectionalTemplate implements ITile
 		return BlockRenderLayer.CUTOUT;
 	}
 
-	@Nullable
 	@Override
-	public TileEntity createNewTileEntity(World worldIn, int meta)
-	{
-		return new MatrixCoreTileEntity();
-	}
+	public boolean hasTileEntity(IBlockState state) { return true; }
+
+	@Override
+	public TileEntity createTileEntity(World world, IBlockState state) { return new MatrixCoreTileEntity(); }
+
 }

--- a/src/main/java/com/aranaira/arcanearchives/blocks/MatrixRepository.java
+++ b/src/main/java/com/aranaira/arcanearchives/blocks/MatrixRepository.java
@@ -3,7 +3,6 @@ package com.aranaira.arcanearchives.blocks;
 import com.aranaira.arcanearchives.ArcaneArchives;
 import com.aranaira.arcanearchives.common.AAGuiHandler;
 import com.aranaira.arcanearchives.tileentities.MatrixRepositoryTileEntity;
-import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.util.ITooltipFlag;
@@ -16,12 +15,11 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
 @ParametersAreNonnullByDefault
-public class MatrixRepository extends BlockTemplate implements ITileEntityProvider
+public class MatrixRepository extends BlockTemplate
 {
 
 	public static final String name = "matrix_repository";
@@ -61,10 +59,10 @@ public class MatrixRepository extends BlockTemplate implements ITileEntityProvid
 	{
 		return false;
 	}
-	@Nullable
+
 	@Override
-	public TileEntity createNewTileEntity(World worldIn, int meta)
-	{
-		return new MatrixRepositoryTileEntity();
-	}
+	public boolean hasTileEntity(IBlockState state) { return true; }
+
+	@Override
+	public TileEntity createTileEntity(World world, IBlockState state) { return new MatrixRepositoryTileEntity(); }
 }

--- a/src/main/java/com/aranaira/arcanearchives/blocks/MatrixStorage.java
+++ b/src/main/java/com/aranaira/arcanearchives/blocks/MatrixStorage.java
@@ -3,7 +3,6 @@ package com.aranaira.arcanearchives.blocks;
 import com.aranaira.arcanearchives.ArcaneArchives;
 import com.aranaira.arcanearchives.common.AAGuiHandler;
 import com.aranaira.arcanearchives.tileentities.MatrixStorageTileEntity;
-import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.util.ITooltipFlag;
@@ -15,10 +14,9 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
-public class MatrixStorage extends BlockTemplate implements ITileEntityProvider
+public class MatrixStorage extends BlockTemplate
 {
 
 	public static final String name = "matrix_storage";
@@ -58,10 +56,10 @@ public class MatrixStorage extends BlockTemplate implements ITileEntityProvider
 	{
 		return false;
 	}
-	@Nullable
+
 	@Override
-	public TileEntity createNewTileEntity(World worldIn, int meta)
-	{
-		return new MatrixStorageTileEntity();
-	}
+	public boolean hasTileEntity(IBlockState state) { return true; }
+
+	@Override
+	public TileEntity createTileEntity(World world, IBlockState state) { return new MatrixStorageTileEntity(); }
 }

--- a/src/main/java/com/aranaira/arcanearchives/blocks/RadiantChest.java
+++ b/src/main/java/com/aranaira/arcanearchives/blocks/RadiantChest.java
@@ -6,7 +6,6 @@ import com.aranaira.arcanearchives.tileentities.RadiantChestTileEntity;
 import com.aranaira.arcanearchives.data.NetworkHelper;
 import com.aranaira.arcanearchives.util.DropHelper;
 import com.aranaira.arcanearchives.util.handlers.AATickHandler;
-import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
@@ -26,7 +25,7 @@ import net.minecraftforge.items.IItemHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-public class RadiantChest extends BlockTemplate implements ITileEntityProvider
+public class RadiantChest extends BlockTemplate
 {
 	public static final String NAME = "radiant_chest";
 
@@ -103,10 +102,10 @@ public class RadiantChest extends BlockTemplate implements ITileEntityProvider
 	}
 
 	@Override
-	public TileEntity createNewTileEntity(@Nonnull World worldIn, int meta)
-	{
-		return new RadiantChestTileEntity();
-	}
+	public boolean hasTileEntity(IBlockState state) { return true; }
+
+	@Override
+	public TileEntity createTileEntity(World world, IBlockState state) { return new RadiantChestTileEntity(); }
 
 	@Override
 	public boolean canEntityDestroy(IBlockState state, IBlockAccess world, BlockPos pos, Entity entity)

--- a/src/main/java/com/aranaira/arcanearchives/blocks/RadiantCraftingTable.java
+++ b/src/main/java/com/aranaira/arcanearchives/blocks/RadiantCraftingTable.java
@@ -3,7 +3,6 @@ package com.aranaira.arcanearchives.blocks;
 import com.aranaira.arcanearchives.ArcaneArchives;
 import com.aranaira.arcanearchives.common.AAGuiHandler;
 import com.aranaira.arcanearchives.tileentities.RadiantCraftingTableTileEntity;
-import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
@@ -15,7 +14,7 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
-public class RadiantCraftingTable extends BlockTemplate implements ITileEntityProvider
+public class RadiantCraftingTable extends BlockTemplate
 {
 
 	public static final String NAME = "radiant_crafting_table";
@@ -49,12 +48,6 @@ public class RadiantCraftingTable extends BlockTemplate implements ITileEntityPr
 	}
 
 	@Override
-	public boolean hasTileEntity(IBlockState state)
-	{
-		return true;
-	}
-
-	@Override
 	public boolean onBlockActivated(World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ)
 	{
 		ArcaneArchives.logger.info("TRYING TO OPEN GUI");
@@ -64,8 +57,11 @@ public class RadiantCraftingTable extends BlockTemplate implements ITileEntityPr
 	}
 
 	@Override
-	public TileEntity createNewTileEntity(@Nonnull World worldIn, int meta)
+	public boolean hasTileEntity(IBlockState state)
 	{
-		return new RadiantCraftingTableTileEntity();
+		return true;
 	}
+
+	@Override
+	public TileEntity createTileEntity(World world, IBlockState state) { return new RadiantCraftingTableTileEntity(); }
 }

--- a/src/main/java/com/aranaira/arcanearchives/blocks/RadiantResonator.java
+++ b/src/main/java/com/aranaira/arcanearchives/blocks/RadiantResonator.java
@@ -3,7 +3,6 @@ package com.aranaira.arcanearchives.blocks;
 import com.aranaira.arcanearchives.tileentities.RadiantResonatorTileEntity;
 import com.aranaira.arcanearchives.util.handlers.ConfigHandler;
 import mcp.MethodsReturnNonnullByDefault;
-import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.tileentity.TileEntity;
@@ -12,13 +11,12 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Random;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class RadiantResonator extends BlockTemplate implements ITileEntityProvider
+public class RadiantResonator extends BlockTemplate
 {
 	public static final String name = "radiant_resonator";
 
@@ -90,10 +88,9 @@ public class RadiantResonator extends BlockTemplate implements ITileEntityProvid
 		return BlockRenderLayer.CUTOUT;
 	}
 
-	@Nullable
 	@Override
-	public TileEntity createNewTileEntity(World worldIn, int meta)
-	{
-		return new RadiantResonatorTileEntity();
-	}
+	public boolean hasTileEntity(IBlockState state) { return true; }
+
+	@Override
+	public TileEntity createTileEntity(World world, IBlockState state) { return new RadiantResonatorTileEntity(); }
 }


### PR DESCRIPTION
Replaces instances of ITileEntityProvider with the `hasTileEntity(){return true}` and `createTileEntity(...``` methods as per general modding recommendations. (Or at least, the general consensus of MMD)

ITileEntityProvider is generally only used by the Block class's `hasTileEntity` and `createTileEntity` methods to my knowledge, but using the methods should allow a little more flexibility to decide whether a block provides one dynamically. Tested briefly with separate sever/client and appears to work as expected.

Also one-line fix for the ghost block placement of blocks on accessors (other blocks may still be an issue) since client tile entities may not have some data like network ID, etc. Tested and worked with separate client/server, more testing is always good though.